### PR TITLE
Fix missing .json file extension when exporting notes

### DIFF
--- a/app/src/main/kotlin/org/fossify/notes/activities/SettingsActivity.kt
+++ b/app/src/main/kotlin/org/fossify/notes/activities/SettingsActivity.kt
@@ -301,7 +301,7 @@ class SettingsActivity : SimpleActivity() {
     private fun setupNotesExport() {
         binding.settingsExportNotesHolder.setOnClickListener {
             ExportNotesDialog(this) { filename ->
-                saveDocument.launch(filename)
+                saveDocument.launch("$filename.json")
             }
         }
     }


### PR DESCRIPTION
This is a fix for #13.

*Update:* https://github.com/FossifyOrg/Notes/issues/13#issuecomment-1913171808 caught me by surprise, need to test that this works properly on more devices (don't want to end up with .json.json as the file extension), so I'm marking as Draft for now. Should also update the commit message to mention that this fix is only required in some circumstances (Android < 10?).

*Update 2:* Done (tested and updated commit message).