### PR TITLE
Added Password Protection (whole app and note deletion)

### DIFF
--- a/app/src/main/kotlin/org/fossify/notes/activities/SettingsActivity.kt
+++ b/app/src/main/kotlin/org/fossify/notes/activities/SettingsActivity.kt
@@ -10,7 +10,9 @@ import androidx.core.view.ViewCompat
 import kotlinx.serialization.SerializationException
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import org.fossify.commons.dialogs.ConfirmationDialog
 import org.fossify.commons.dialogs.RadioGroupDialog
+import org.fossify.commons.dialogs.SecurityDialog
 import org.fossify.commons.extensions.*
 import org.fossify.commons.helpers.*
 import org.fossify.commons.models.RadioItem
@@ -62,6 +64,7 @@ class SettingsActivity : SimpleActivity() {
         setupNotesImport()
         setupEnableAutomaticBackups()
         setupManageAutomaticBackups()
+        setupAppPasswordProtection()
         updateTextColors(binding.settingsNestedScrollview)
 
         arrayOf(
@@ -394,5 +397,27 @@ class SettingsActivity : SimpleActivity() {
         config.autoBackup = enable
         binding.settingsEnableAutomaticBackups.isChecked = enable
         binding.settingsManageAutomaticBackupsHolder.beVisibleIf(enable)
+    }
+
+    private fun setupAppPasswordProtection() {
+        binding.settingsAppPasswordProtection.isChecked = config.isAppPasswordProtectionOn
+        binding.settingsAppPasswordProtectionHolder.setOnClickListener {
+            val tabToShow = if (config.isAppPasswordProtectionOn) config.appProtectionType else SHOW_ALL_TABS
+            SecurityDialog(this, config.appPasswordHash, tabToShow) { hash, type, success ->
+                if (success) {
+                    val hasPasswordProtection = config.isAppPasswordProtectionOn
+                    binding.settingsAppPasswordProtection.isChecked = !hasPasswordProtection
+                    config.isAppPasswordProtectionOn = !hasPasswordProtection
+                    config.appPasswordHash = if (hasPasswordProtection) "" else hash
+                    config.appProtectionType = type
+
+                    if (config.isAppPasswordProtectionOn) {
+                        val confirmationTextId = if (config.appProtectionType == PROTECTION_FINGERPRINT)
+                            org.fossify.commons.R.string.fingerprint_setup_successfully else org.fossify.commons.R.string.protection_setup_successfully
+                        ConfirmationDialog(this, "", confirmationTextId, org.fossify.commons.R.string.ok, 0) { }
+                    }
+                }
+            }
+        }
     }
 }

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -412,6 +412,32 @@
 
             </RelativeLayout>
 
+            <include
+                android:id="@+id/settings_extended_details_divider"
+                layout="@layout/divider" />
+
+            <TextView
+                android:id="@+id/settings_security_label"
+                style="@style/SettingsSectionLabelStyle"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/security" />
+
+            <RelativeLayout
+                android:id="@+id/settings_app_password_protection_holder"
+                style="@style/SettingsHolderCheckboxStyle"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
+
+                <org.fossify.commons.views.MyAppCompatCheckbox
+                    android:id="@+id/settings_app_password_protection"
+                    style="@style/SettingsCheckboxStyle"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/password_protect_whole_app" />
+
+            </RelativeLayout>
+
             <RelativeLayout
                 android:id="@+id/settings_manage_automatic_backups_holder"
                 style="@style/SettingsHolderTextViewOneLinerStyle"


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving Fossify. Please consider filling out the details :)-->

I have made the modifications for this second pull request as requested.

#### What is it?
- [ ] Bugfix
- [x] Feature
- [ ] Codebase improvement

This is the link of the feature request :
[https://github.com/FossifyOrg/Notes/issues/17](https://github.com/FossifyOrg/Notes/issues/17)

#### Description of the changes and new features
<!-- Bullet points are preferred. The following is an example -->
- Added Password protect the whole aplication
- Added Password of the app protect notes deletion
- Added a new settings section to the settings menu, with a checkbox to enable or disable application password protection.
(Request user to create a password)

#### Screenshots
<!-- If your PR changes the app's UI in any way, consider including screenshots or a video showing exactly what changed, so that developers and users can pinpoint it easily. Delete this if it doesn't apply to your PR.-->
- New Settings "password" added in settings menu: 
![Capture d'écran 2024-02-17 173145](https://github.com/FossifyOrg/Notes/assets/150960856/cc08a7c3-2dbf-4897-ac64-639ffd36db3d)
- App protection at start:
![Capture d'écran 2024-02-17 173248](https://github.com/FossifyOrg/Notes/assets/150960856/8fa2f07b-596d-412d-8a65-c4a587fd45f8)
- Notes deletion protection (after confirmation delete):
![Capture d'écran 2024-02-16 223736](https://github.com/FossifyOrg/Notes/assets/150960856/23ebcc56-6964-4070-8df8-5c029f0cd3db)

#### Acknowledgement
- [x] I read the [contribution guidelines](https://github.com/FossifyOrg/Notes/blob/master/CONTRIBUTING.md).