### PR TITLE
Added sorting after renaming and checking/unchecking checklist item

### DIFF
--- a/app/src/main/kotlin/org/fossify/notes/adapters/ChecklistAdapter.kt
+++ b/app/src/main/kotlin/org/fossify/notes/adapters/ChecklistAdapter.kt
@@ -116,9 +116,11 @@ class ChecklistAdapter(
         RenameChecklistItemDialog(activity, item.title) {
             val position = getSelectedItemPositions().first()
             item.title = it
-            listener?.saveChecklist()
             notifyItemChanged(position)
             finishActMode()
+            listener?.saveChecklist {
+                listener.refreshItems()
+            }
         }
     }
 

--- a/app/src/main/kotlin/org/fossify/notes/fragments/ChecklistFragment.kt
+++ b/app/src/main/kotlin/org/fossify/notes/fragments/ChecklistFragment.kt
@@ -185,6 +185,7 @@ class ChecklistFragment : NoteFragment(), ChecklistItemsListener {
 
             saveNote(items.indexOfFirst { it.id == clickedNote.id })
             context?.updateWidgets()
+            refreshItems()
         }.apply {
             binding.checklistList.adapter = this
         }


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving Fossify. Please consider filling out the details :)-->

#### What is it?
- [X] Bugfix
- [ ] Feature
- [ ] Codebase improvement

#### Description of the changes in your PR
- Currently, sorting in checklist is applied only after adding new item or reloading the app. This PR also adds sorting after renaming item and checking/unchecking. 
    - Deleting also doesn't trigger sorting, but when other actions do it, delete doesn't need to sort.
- Probably sorting after checking/unchecking should be done a bit nicer visually, maybe with some delay or animation so users will know what happened if a click was accidental.

#### Before/After Screenshots/Screen Record
<!-- If your PR changes the app's UI in any way, consider including screenshots or a video showing exactly what changed, so that developers and users can pinpoint it easily. Delete this if it doesn't apply to your PR.-->
- Before:

https://github.com/FossifyOrg/Notes/assets/85929121/a69a0806-9500-447a-b3c3-77f9f5666afc

- After:

https://github.com/FossifyOrg/Notes/assets/85929121/a65e9413-d667-4b33-a27c-49818ee993bb

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #40 - automatic sorting after checking/unchecking should cover this report. Users just need to remember to check the proper checkbox in the sorting dialog.

#### Acknowledgement
- [x] I read the [contribution guidelines](https://github.com/FossifyOrg/Notes/blob/master/CONTRIBUTING.md).
