### PR TITLE
Fixed showing note picker before unlocking the app (#46)

### DIFF
--- a/app/src/main/kotlin/org/fossify/notes/activities/MainActivity.kt
+++ b/app/src/main/kotlin/org/fossify/notes/activities/MainActivity.kt
@@ -116,9 +116,6 @@ class MainActivity : SimpleActivity() {
         checkIntents(intent)
 
         storeStateVariables()
-        if (config.showNotePicker && savedInstanceState == null && hasNoIntent) {
-            displayOpenNoteDialog()
-        }
 
         wasInit = true
 
@@ -127,6 +124,10 @@ class MainActivity : SimpleActivity() {
 
         mIsPasswordProtectionPending = config.isAppPasswordProtectionOn
 
+        if (config.showNotePicker && savedInstanceState == null && hasNoIntent && !mIsPasswordProtectionPending) {
+            displayOpenNoteDialog()
+        }
+
         if (savedInstanceState == null) {
             binding.viewPager.beGoneIf(mIsPasswordProtectionPending)
             if (mIsPasswordProtectionPending && !mWasProtectionHandled) {
@@ -134,6 +135,9 @@ class MainActivity : SimpleActivity() {
                     mWasProtectionHandled = it
                     if (it) {
                         mIsPasswordProtectionPending = false
+                        if (config.showNotePicker && savedInstanceState == null && hasNoIntent) {
+                            displayOpenNoteDialog()
+                        }
                         binding.viewPager.beVisible()
                     } else {
                         finish()


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving Fossify. Please consider filling out the details :)-->

#### What is it?
- [x] Bugfix
- [ ] Feature
- [ ] Codebase improvement

#### Description of the changes in your PR
<!-- Bullet points are preferred. The following is an example -->
- Moved condition whether to show note picker after the check if the app is password protected.
- Added similar condition after unlocking the app.

#### Before/After Screenshots/Screen Record
<!-- If your PR changes the app's UI in any way, consider including screenshots or a video showing exactly what changed, so that developers and users can pinpoint it easily. Delete this if it doesn't apply to your PR.-->
- Before:

https://github.com/FossifyOrg/Notes/assets/85929121/1218fb6c-10a7-44a5-939e-00984fc8bc2c

- After:

https://github.com/FossifyOrg/Notes/assets/85929121/374dc110-b694-47e1-8e6d-7395ba7143f0

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #46 

#### Acknowledgement
- [x] I read the [contribution guidelines](https://github.com/FossifyOrg/Notes/blob/master/CONTRIBUTING.md).
