### PR TITLE
Allow importing files with MIME type "application/octet-stream"

### DIFF
--- a/app/src/main/kotlin/org/fossify/notes/activities/SettingsActivity.kt
+++ b/app/src/main/kotlin/org/fossify/notes/activities/SettingsActivity.kt
@@ -32,6 +32,14 @@ import kotlin.system.exitProcess
 
 class SettingsActivity : SimpleActivity() {
     private val notesFileType = "application/json"
+    private val notesImportFileTypes = buildList {
+        add("application/json")
+        if (!isQPlus()) {
+            // Workaround for https://github.com/FossifyOrg/Notes/issues/34
+            add("application/octet-stream")
+        }
+    }
+
     private val binding by viewBinding(ActivitySettingsBinding::inflate)
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -89,12 +97,13 @@ class SettingsActivity : SimpleActivity() {
         return super.onCreateOptionsMenu(menu)
     }
 
-    private val getContent = registerForActivityResult(ActivityResultContracts.GetContent()) { uri ->
-        if (uri != null) {
-            toast(org.fossify.commons.R.string.importing)
-            importNotes(uri)
+    private val getContent =
+        registerForActivityResult(ActivityResultContracts.OpenDocument()) { uri ->
+            if (uri != null) {
+                toast(org.fossify.commons.R.string.importing)
+                importNotes(uri)
+            }
         }
-    }
 
     private val saveDocument = registerForActivityResult(ActivityResultContracts.CreateDocument(notesFileType)) { uri ->
         if (uri != null) {
@@ -315,7 +324,7 @@ class SettingsActivity : SimpleActivity() {
 
     private fun setupNotesImport() {
         binding.settingsImportNotesHolder.setOnClickListener {
-            getContent.launch(notesFileType)
+            getContent.launch(notesImportFileTypes.toTypedArray())
         }
     }
 


### PR DESCRIPTION
Ported from FossifyOrg/Messages#137.

Sometimes Android reports the MIME type as "application/octet-stream" even if the file has a .json extension (specifically, on Android 8 and 9 for backups exported outside the Download folder). Previously, such files could not be selected in the file picker when importing.

As a workaround, allow files with that MIME type on Android < 10.

#### What is it?
- [x] Bugfix
- [ ] Feature
- [ ] Codebase improvement

#### Description of the changes in your PR
- Allow importing files with MIME type "application/octet-stream" on Android < 10

#### Fixes the following issue(s)
- Fixes #34

#### Acknowledgement
- [x] I read the [contribution guidelines](https://github.com/FossifyOrg/Notes/blob/master/CONTRIBUTING.md).
