### PR TITLE
Fixed multiline pasting for checklist (#99)

### DIFF
--- a/app/src/main/kotlin/org/fossify/notes/dialogs/NewChecklistItemDialog.kt
+++ b/app/src/main/kotlin/org/fossify/notes/dialogs/NewChecklistItemDialog.kt
@@ -57,7 +57,7 @@ class NewChecklistItemDialog(val activity: Activity, callback: (titles: ArrayLis
             }
     }
 
-    private fun addNewEditText() {
+    private fun addNewEditText(initialText: String? = null) {
         ItemAddChecklistBinding.inflate(activity.layoutInflater).apply {
             titleEditText.setOnEditorActionListener { _, actionId, _ ->
                 if (actionId == EditorInfo.IME_ACTION_NEXT || actionId == EditorInfo.IME_ACTION_DONE || actionId == KeyEvent.KEYCODE_ENTER) {
@@ -66,6 +66,21 @@ class NewChecklistItemDialog(val activity: Activity, callback: (titles: ArrayLis
                 } else {
                     false
                 }
+            }
+            titleEditText.onTextChangeListener { text ->
+                val lines = text.split("\n").filter { it.trim().isNotEmpty() }
+                if (lines.size > 1) {
+                    lines.forEachIndexed { i, line ->
+                        if (i == 0) {
+                            titleEditText.setText(line)
+                        } else {
+                            addNewEditText(line)
+                        }
+                    }
+                }
+            }
+            if (initialText != null) {
+                titleEditText.setText(initialText)
             }
             titles.add(titleEditText)
             binding.checklistHolder.addView(this.root)


### PR DESCRIPTION
<!-- Hey there. Thank you so much for improving Fossify. Please consider filling out the details :)-->

#### What is it?
- [x] Bugfix
- [ ] Feature
- [ ] Codebase improvement

#### Description of the changes in your PR
<!-- Bullet points are preferred. The following is an example -->
Added splitting of multiline text into separate editors.

#### Before/After Screenshots/Screen Record
<!-- If your PR changes the app's UI in any way, consider including screenshots or a video showing exactly what changed, so that developers and users can pinpoint it easily. Delete this if it doesn't apply to your PR.-->
- Before:

https://github.com/user-attachments/assets/6061ff9b-713c-4ace-8c56-c58a4c89dffe

- After:

https://github.com/user-attachments/assets/3bb57812-8910-422e-9c82-e3ecf51645e5

#### Fixes the following issue(s)
<!-- Prefix issues with "Fixes" so that GitHub closes them when the PR is merged (note that each "Fixes #" should be in its own item). Also add any other relevant links. -->
- Fixes #99 

#### Acknowledgement
- [x] I read the [contribution guidelines](https://github.com/FossifyOrg/Notes/blob/master/CONTRIBUTING.md).
