### PR TITLE
fix: use incognito mode in checklists

### DIFF
--- a/app/src/main/kotlin/org/fossify/notes/dialogs/EditTaskDialog.kt
+++ b/app/src/main/kotlin/org/fossify/notes/dialogs/EditTaskDialog.kt
@@ -2,13 +2,23 @@ package org.fossify.notes.dialogs
 
 import android.app.Activity
 import android.content.DialogInterface.BUTTON_POSITIVE
+import android.view.inputmethod.EditorInfo
 import org.fossify.commons.extensions.*
 import org.fossify.notes.databinding.DialogRenameChecklistItemBinding
+import org.fossify.notes.extensions.config
 
 class EditTaskDialog(val activity: Activity, val oldTitle: String, callback: (newTitle: String) -> Unit) {
     init {
         val binding = DialogRenameChecklistItemBinding.inflate(activity.layoutInflater).apply {
             checklistItemTitle.setText(oldTitle)
+
+            if (activity.config.useIncognitoMode == true) {
+                checklistItemTitle.imeOptions =
+                    checklistItemTitle.imeOptions or EditorInfo.IME_FLAG_NO_PERSONALIZED_LEARNING
+            } else {
+                checklistItemTitle.imeOptions =
+                    checklistItemTitle.imeOptions.removeBit(EditorInfo.IME_FLAG_NO_PERSONALIZED_LEARNING)
+            }
         }
 
         activity.getAlertDialogBuilder()

--- a/app/src/main/kotlin/org/fossify/notes/dialogs/EditTaskDialog.kt
+++ b/app/src/main/kotlin/org/fossify/notes/dialogs/EditTaskDialog.kt
@@ -2,23 +2,15 @@ package org.fossify.notes.dialogs
 
 import android.app.Activity
 import android.content.DialogInterface.BUTTON_POSITIVE
-import android.view.inputmethod.EditorInfo
 import org.fossify.commons.extensions.*
 import org.fossify.notes.databinding.DialogRenameChecklistItemBinding
-import org.fossify.notes.extensions.config
+import org.fossify.notes.extensions.maybeRequestIncognito
 
 class EditTaskDialog(val activity: Activity, val oldTitle: String, callback: (newTitle: String) -> Unit) {
     init {
         val binding = DialogRenameChecklistItemBinding.inflate(activity.layoutInflater).apply {
             checklistItemTitle.setText(oldTitle)
-
-            if (activity.config.useIncognitoMode == true) {
-                checklistItemTitle.imeOptions =
-                    checklistItemTitle.imeOptions or EditorInfo.IME_FLAG_NO_PERSONALIZED_LEARNING
-            } else {
-                checklistItemTitle.imeOptions =
-                    checklistItemTitle.imeOptions.removeBit(EditorInfo.IME_FLAG_NO_PERSONALIZED_LEARNING)
-            }
+            checklistItemTitle.maybeRequestIncognito()
         }
 
         activity.getAlertDialogBuilder()

--- a/app/src/main/kotlin/org/fossify/notes/dialogs/NewChecklistItemDialog.kt
+++ b/app/src/main/kotlin/org/fossify/notes/dialogs/NewChecklistItemDialog.kt
@@ -94,6 +94,15 @@ class NewChecklistItemDialog(
                 titles.add(titleEditText)
                 binding.checklistHolder.addView(this.root)
             }
+
+            if (activity.config.useIncognitoMode == true) {
+                titleEditText.imeOptions =
+                    titleEditText.imeOptions or EditorInfo.IME_FLAG_NO_PERSONALIZED_LEARNING
+            } else {
+                titleEditText.imeOptions =
+                    titleEditText.imeOptions.removeBit(EditorInfo.IME_FLAG_NO_PERSONALIZED_LEARNING)
+            }
+
             activity.updateTextColors(binding.checklistHolder)
             binding.dialogHolder.post {
                 binding.dialogHolder.fullScroll(View.FOCUS_DOWN)

--- a/app/src/main/kotlin/org/fossify/notes/dialogs/NewChecklistItemDialog.kt
+++ b/app/src/main/kotlin/org/fossify/notes/dialogs/NewChecklistItemDialog.kt
@@ -13,6 +13,7 @@ import org.fossify.notes.R
 import org.fossify.notes.databinding.DialogNewChecklistItemBinding
 import org.fossify.notes.databinding.ItemAddChecklistBinding
 import org.fossify.notes.extensions.config
+import org.fossify.notes.extensions.maybeRequestIncognito
 
 class NewChecklistItemDialog(
     val activity: Activity,
@@ -95,13 +96,7 @@ class NewChecklistItemDialog(
                 binding.checklistHolder.addView(this.root)
             }
 
-            if (activity.config.useIncognitoMode == true) {
-                titleEditText.imeOptions =
-                    titleEditText.imeOptions or EditorInfo.IME_FLAG_NO_PERSONALIZED_LEARNING
-            } else {
-                titleEditText.imeOptions =
-                    titleEditText.imeOptions.removeBit(EditorInfo.IME_FLAG_NO_PERSONALIZED_LEARNING)
-            }
+            titleEditText.maybeRequestIncognito()
 
             activity.updateTextColors(binding.checklistHolder)
             binding.dialogHolder.post {

--- a/app/src/main/kotlin/org/fossify/notes/extensions/TextView.kt
+++ b/app/src/main/kotlin/org/fossify/notes/extensions/TextView.kt
@@ -1,0 +1,13 @@
+package org.fossify.notes.extensions
+
+import android.view.inputmethod.EditorInfo
+import android.widget.TextView
+import org.fossify.commons.extensions.removeBit
+
+fun TextView.maybeRequestIncognito() {
+    imeOptions = if (context.config.useIncognitoMode) {
+        imeOptions or EditorInfo.IME_FLAG_NO_PERSONALIZED_LEARNING
+    } else {
+        imeOptions.removeBit(EditorInfo.IME_FLAG_NO_PERSONALIZED_LEARNING)
+    }
+}

--- a/app/src/main/kotlin/org/fossify/notes/fragments/TextFragment.kt
+++ b/app/src/main/kotlin/org/fossify/notes/fragments/TextFragment.kt
@@ -14,7 +14,6 @@ import android.view.LayoutInflater
 import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
-import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.InputMethodManager
 import android.widget.ImageView
 import android.widget.TextView
@@ -28,6 +27,7 @@ import org.fossify.notes.databinding.NoteViewHorizScrollableBinding
 import org.fossify.notes.databinding.NoteViewStaticBinding
 import org.fossify.notes.extensions.config
 import org.fossify.notes.extensions.getPercentageFontSize
+import org.fossify.notes.extensions.maybeRequestIncognito
 import org.fossify.notes.extensions.updateWidgets
 import org.fossify.notes.helpers.MyMovementMethod
 import org.fossify.notes.helpers.NOTE_ID
@@ -172,12 +172,7 @@ class TextFragment : NoteFragment() {
                     }
                 }
             }
-
-            imeOptions = if (config.useIncognitoMode) {
-                imeOptions or EditorInfo.IME_FLAG_NO_PERSONALIZED_LEARNING
-            } else {
-                imeOptions.removeBit(EditorInfo.IME_FLAG_NO_PERSONALIZED_LEARNING)
-            }
+            maybeRequestIncognito()
         }
 
         noteEditText.setOnTouchListener { v, event ->


### PR DESCRIPTION
<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [x] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
The EditTextDialog and NewChecklistItemDialog now use the keyboard incognito mode as requested in  #74 

#### Before/After Screenshots/Screen Record
Before can be seen in the issue
After:
<img src="https://github.com/user-attachments/assets/50f72b1f-3706-4d8a-bb72-ae241f3014f2" width="250">
<img src="https://github.com/user-attachments/assets/691a6da4-f917-49e4-97b4-1a8ba8b6f5c9" width="250">

#### Fixes the following issue(s)
- Fixes #74 

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [ ] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [ ] All checks are passing.
