### PR TITLE
fix: only clear span when `Spanned.SPAN_COMPOSING` is not set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fixed broken input when typing with certain keyboards ([#178])
+
 ## [1.3.0] - 2025-07-12
 ### Changed
 - Updated translations
@@ -55,6 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#99]: https://github.com/FossifyOrg/Notes/issues/99
 [#110]: https://github.com/FossifyOrg/Notes/issues/110
 [#164]: https://github.com/FossifyOrg/Notes/issues/164
+[#178]: https://github.com/FossifyOrg/Notes/issues/178
 
 [Unreleased]: https://github.com/FossifyOrg/Notes/compare/v1.3.0...HEAD
 [1.3.0]: https://github.com/FossifyOrg/Notes/compare/v1.2.0...v1.3.0

--- a/app/src/main/kotlin/org/fossify/notes/extensions/EditText.kt
+++ b/app/src/main/kotlin/org/fossify/notes/extensions/EditText.kt
@@ -6,8 +6,13 @@ import org.fossify.commons.views.MyEditText
 
 fun MyEditText.enforcePlainText() {
     val stripSpans = InputFilter { source, start, end, _, _, _ ->
-        val sub = source.subSequence(start, end)
-        if (sub is Spanned) sub.toString() else sub
+        if (source !is Spanned) return@InputFilter null
+        val hasRealStyle = source.getSpans(start, end, Any::class.java)
+            .any { span ->
+                (source.getSpanFlags(span) and Spanned.SPAN_COMPOSING) == 0
+            }
+
+        if (hasRealStyle) source.subSequence(start, end).toString() else null
     }
     filters = (filters ?: emptyArray()) + stripSpans
 }


### PR DESCRIPTION
Fixes https://github.com/FossifyOrg/Notes/issues/178