### PR TITLE
Add "Make a copy" functionality

### DIFF
--- a/app/src/main/kotlin/org/fossify/notes/activities/MainActivity.kt
+++ b/app/src/main/kotlin/org/fossify/notes/activities/MainActivity.kt
@@ -321,6 +321,7 @@ class MainActivity : SimpleActivity() {
                 R.id.remove_done_items -> fragment?.handleUnlocking { removeDoneItems() }
                 R.id.uncheck_all_items -> fragment?.handleUnlocking { uncheckAllItems() }
                 R.id.sort_checklist -> fragment?.handleUnlocking { displaySortChecklistDialog() }
+                R.id.copy_note -> fragment?.handleUnlocking { copyNote() }
                 else -> return@setOnMenuItemClickListener false
             }
             return@setOnMenuItemClickListener true
@@ -1591,6 +1592,39 @@ class MainActivity : SimpleActivity() {
         SortChecklistDialog(this, mCurrentNote.id) {
             getPagerAdapter().refreshChecklist(binding.viewPager.currentItem)
             updateWidgets()
+        }
+    }
+
+    private fun copyNote() {
+
+        val text = if (mCurrentNote.type == NoteType.TYPE_TEXT) {
+            getCurrentNoteText()
+        } else {
+            mCurrentNote.value
+        }
+
+        if (text.isNullOrEmpty()) {
+            toast(R.string.cannot_copy_empty_text)
+            return
+        }
+
+        NotesHelper(this).getNotes {
+            val notes = it
+            val list = arrayListOf<RadioItem>().apply {
+                add(RadioItem(0, getString(R.string.create_new_note)))
+                notes.forEachIndexed { index, note ->
+                    add(RadioItem(index + 1, note.title))
+                }
+            }
+
+            RadioGroupDialog(this, list, -1, R.string.add_to_note) {
+                if (it as Int == 0) {
+                    displayNewNoteDialog(text)
+                } else {
+                    updateSelectedNote(notes[it - 1].id!!)
+                    addTextToCurrentNote(if (mCurrentNote.value.isEmpty()) text else "\n$text")
+                }
+            }
         }
     }
 }

--- a/app/src/main/res/menu/menu.xml
+++ b/app/src/main/res/menu/menu.xml
@@ -50,6 +50,10 @@
         android:title="@string/sort_by"
         app:showAsAction="ifRoom" />
     <item
+        android:id="@+id/copy_note"
+        android:title="@string/copy_note"
+        app:showAsAction="ifRoom" />
+    <item
         android:id="@+id/share"
         android:icon="@drawable/ic_share_vector"
         android:title="@string/share"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,7 +15,7 @@
     <string name="general_note">General note</string>
     <string name="create_new_note">Create a new note</string>
     <string name="add_to_note">Add to note</string>
-    <string name="copy_note">Copy note</string>
+    <string name="copy_note">Make a copy</string>
     <string name="unsaved_changes_warning">You have some unsaved changes. What do you want to do with them?</string>
     <string name="note_shown_widget">Note shown in the widget:</string>
     <string name="show_note_title">Show note title</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,6 +3,7 @@
     <string name="app_launcher_name">Notes</string>
     <string name="widget_config">Thank you for using Fossify Notes.\nFor more apps from Fossify, please visit fossify.org.</string>
     <string name="cannot_share_empty_text">Cannot share empty text</string>
+    <string name="cannot_copy_empty_text">Cannot copy empty text</string>
     <string name="new_note">Add a new note</string>
     <string name="no_title">Please name your note</string>
     <string name="title_taken">A note with that title already exists</string>
@@ -14,6 +15,7 @@
     <string name="general_note">General note</string>
     <string name="create_new_note">Create a new note</string>
     <string name="add_to_note">Add to note</string>
+    <string name="copy_note">Copy note</string>
     <string name="unsaved_changes_warning">You have some unsaved changes. What do you want to do with them?</string>
     <string name="note_shown_widget">Note shown in the widget:</string>
     <string name="show_note_title">Show note title</string>


### PR DESCRIPTION

#### Type of change(s)
- [ ] Bug fix
- [x] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation



#### Before & after preview
**Before:**

[Before.webm](https://github.com/user-attachments/assets/6e06f295-db80-4ed3-8d30-01a351d151f1)

**After:**

[After.webm](https://github.com/user-attachments/assets/c0905ef6-42b7-4aba-ac44-10ee882df36d)


#### What changed and why
- Added a **"Make a copy"** option in the note’s "More options" menu.
- This allows users to duplicate an existing note quickly, optionally renaming it.
- Improves UI/UX by reducing steps required for duplication:
  - Before: More options → Share → Select Fossify Notes → Create new note → Enter name
  - After: More options → Make a copy → Enter name (optional)


#### Closes the following issue(s)

- Closes #98 

#### Checklist
- [YES ] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [ YES] I manually tested my changes on device/emulator

