### PR TITLE
Improve Android build and run instructions for new contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,23 @@ Experience the simplicity and efficiency of note-taking with Fossify Notes. Down
 <img alt="App image" src="fastlane/metadata/android/en-US/images/phoneScreenshots/2_en-US.png" width="30%">
 <img alt="App image" src="fastlane/metadata/android/en-US/images/phoneScreenshots/3_en-US.png" width="30%">
 </div>
+
+## Build & Run (Android)
+
+### Requirements
+- Android Studio Hedgehog or newer
+- Android SDK 30+
+- Gradle (bundled with Android Studio)
+
+### Steps
+1. Clone the repository
+2. Open the project in Android Studio
+3. Allow Gradle sync to complete
+4. Select the `appDebug` build variant
+5. Run the app on:
+   - Emulator (API 30+ recommended), or
+   - Physical device with USB debugging enabled
+
+### Notes
+- First Gradle sync may take a few minutes
+- If sync fails, try **Invalidate Caches & Restart**


### PR DESCRIPTION
<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [ ] Bug fix
- [ ] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [x] Documentation

#### What changed and why
The README previously lacked clear, step-by-step instructions for building and running the project in Android Studio. 
This can confuse new contributors who are unfamiliar with the required Android SDK level, build variants, or emulator setup.

This PR adds:
- A dedicated "Build & Run" section
- Recommended Android Studio version
- Required SDK version and Gradle sync notes
- Steps for selecting the correct build variant
- Emulator requirements for testing

These improvements help new contributors set up the development environment quickly and avoid common setup errors.

#### Tests performed
Documentation-only change.  
No code, UI, or functional behavior affected by this update.

#### Before & after preview
_Not applicable (documentation change only)._

#### Closes the following issue(s)
_No related issue._

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually reviewed my changes (formatting, clarity, no typos).
- [ ] I updated the "Unreleased" section in `CHANGELOG.md` (not applicable for docs-only change).
- [x] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [x] All checks are passing.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
