### PR TITLE
feat: share checklists as simple text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for custom fonts
 
 ### Changed
+- Checklists are now shared as plain text ([#96])
 - Disabled touch outside the checklist dialog to prevent loss of content ([#291])
 
 ### Fixed
@@ -102,6 +103,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#59]: https://github.com/FossifyOrg/Notes/issues/59
 [#81]: https://github.com/FossifyOrg/Notes/issues/81
 [#83]: https://github.com/FossifyOrg/Notes/issues/83
+[#96]: https://github.com/FossifyOrg/Notes/issues/96
 [#99]: https://github.com/FossifyOrg/Notes/issues/99
 [#110]: https://github.com/FossifyOrg/Notes/issues/110
 [#156]: https://github.com/FossifyOrg/Notes/issues/156

--- a/app/src/main/kotlin/org/fossify/notes/activities/MainActivity.kt
+++ b/app/src/main/kotlin/org/fossify/notes/activities/MainActivity.kt
@@ -104,6 +104,7 @@ import org.fossify.notes.dialogs.OpenFileDialog
 import org.fossify.notes.dialogs.OpenNoteDialog
 import org.fossify.notes.dialogs.RenameNoteDialog
 import org.fossify.notes.dialogs.SortChecklistDialog
+import org.fossify.notes.extensions.checklistToPlainText
 import org.fossify.notes.extensions.config
 import org.fossify.notes.extensions.getPercentageFontSize
 import org.fossify.notes.extensions.notesDB
@@ -1457,7 +1458,7 @@ class MainActivity : SimpleActivity() {
         val text = if (mCurrentNote.type == NoteType.TYPE_TEXT) {
             getCurrentNoteText()
         } else {
-            mCurrentNote.value
+            mCurrentNote.value.checklistToPlainText(config.moveDoneChecklistItems) ?: mCurrentNote.value
         }
 
         if (text.isNullOrEmpty()) {

--- a/app/src/main/kotlin/org/fossify/notes/extensions/String.kt
+++ b/app/src/main/kotlin/org/fossify/notes/extensions/String.kt
@@ -14,3 +14,12 @@ fun String.parseChecklistItems(): ArrayList<Task>? {
     }
     return null
 }
+
+fun String.checklistToPlainText(moveDoneToBottom: Boolean = true): String? {
+    val tasks = parseChecklistItems() ?: return null
+    val sortedTasks = if (moveDoneToBottom) tasks.sortedBy { it.isDone } else tasks
+    return sortedTasks.joinToString("\n") { task ->
+        val checkbox = if (task.isDone) "[x]" else "[ ]"
+        "$checkbox ${task.title}"
+    }
+}


### PR DESCRIPTION
<!-- Thank you for improving Fossify. Please consider filling out the details -->

#### Type of change(s)
- [ ] Bug fix
- [x] Feature / enhancement
- [ ] Infrastructure / tooling (CI, build, deps, tests)
- [ ] Documentation

#### What changed and why
<!-- Briefly explain the rationale. The following is an example -->
Modified the share functionality to share plan checklists as plain text. In-app sorting is respected in the final text.

#### Tests performed
<!-- If applicable, test your changes on different devices and conditions as mentioned in the guidelines (you can decide what tests to do based on your patches). Delete this section otherwise. -->
 - Tested sharing checklists with all sorting options

#### Before & after preview
<!-- For changes affecting UI, consider attaching screenshots or a video. Delete this section otherwise. -->

Items are shared in the following format:

```
[x] Timothy hay
[x] Pellets
[ ] Low-pile carpets
[x] Bananas
```

#### Closes the following issue(s)
<!-- Prefix issues with "Closes" so that GitHub closes them when the PR is merged (note that each "Closes #" should be in its own item). -->
- Closes https://github.com/FossifyOrg/Notes/issues/96

#### Checklist
- [x] I read the [contribution guidelines](../blob/HEAD/CONTRIBUTING.md).
- [x] I manually tested my changes on device/emulator (if applicable).
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [x] All checks are passing.

<!-- NOTE: Keep CHANGELOG.md updates clear and concise, they are visible to *all* users. -->
