### PR TITLE
Print WebView: surface main-frame load errors with a toast

### DIFF
--- a/app/src/main/kotlin/org/fossify/notes/activities/MainActivity.kt
+++ b/app/src/main/kotlin/org/fossify/notes/activities/MainActivity.kt
@@ -24,6 +24,7 @@ import android.view.ActionMode
 import android.view.Gravity
 import android.view.MenuItem
 import android.view.inputmethod.EditorInfo
+import android.webkit.WebResourceError
 import android.webkit.WebResourceRequest
 import android.webkit.WebView
 import android.webkit.WebViewClient
@@ -1285,6 +1286,13 @@ class MainActivity : SimpleActivity() {
 
                 override fun onPageFinished(view: WebView, url: String) {
                     createWebPrintJob(view)
+                }
+
+                override fun onReceivedError(view: WebView, request: WebResourceRequest, error: WebResourceError) {
+                    super.onReceivedError(view, request, error)
+                    if (request.isForMainFrame) {
+                        toast(org.fossify.commons.R.string.unknown_error_occurred)
+                    }
                 }
             }
 


### PR DESCRIPTION
Closes #364.

The print flow uses a hidden `WebView` whose `WebViewClient` only overrides `shouldOverrideUrlLoading` and `onPageFinished`. `onPageFinished` is what kicks off `createWebPrintJob`, so if the underlying `loadData` fails (large note, transient renderer error, etc.) the print silently never starts and the user gets no feedback at all.

This PR adds `onReceivedError` on the same anonymous `WebViewClient`:

```kotlin
override fun onReceivedError(view: WebView, request: WebResourceRequest, error: WebResourceError) {
    super.onReceivedError(view, request, error)
    if (request.isForMainFrame) {
        toast(org.fossify.commons.R.string.unknown_error_occurred)
    }
}
```

Why this shape:

- `request.isForMainFrame` guards against firing the toast twice if any sub-resource also fails (the WebView is loading text via `loadData`, so sub-resources should not really exist, but the guard keeps the override future-proof).
- The fully qualified `org.fossify.commons.R.string.unknown_error_occurred` is reused so the message stays already translated. The same string is used elsewhere in this activity from `showErrorToast`, which keeps the failure UX consistent with the rest of the print pipeline.
- Only one new import (`android.webkit.WebResourceError`). No new permission, no new resource, no behaviour change on successful prints.