### PR TITLE
fix: keep the Save icon hidden on already-saved text notes after swiping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixed the Save icon reappearing on an already-saved note after swiping between notes with autosave turned off ([#210])
 
 ## [1.7.0] - 2026-01-30
 ### Added
@@ -115,6 +117,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#178]: https://github.com/FossifyOrg/Notes/issues/178
 [#190]: https://github.com/FossifyOrg/Notes/issues/190
 [#201]: https://github.com/FossifyOrg/Notes/issues/201
+[#210]: https://github.com/FossifyOrg/Notes/issues/210
 [#291]: https://github.com/FossifyOrg/Notes/issues/291
 
 [Unreleased]: https://github.com/FossifyOrg/Notes/compare/1.7.0...HEAD

--- a/app/src/main/kotlin/org/fossify/notes/activities/MainActivity.kt
+++ b/app/src/main/kotlin/org/fossify/notes/activities/MainActivity.kt
@@ -1342,6 +1342,8 @@ class MainActivity : SimpleActivity() {
         if (mCurrentNote.type == NoteType.TYPE_CHECKLIST) {
             mCurrentNote.value = getPagerAdapter()
                 .getNoteChecklistItems(binding.viewPager.currentItem) ?: ""
+        } else {
+            mCurrentNote.value = getCurrentNoteText() ?: mCurrentNote.value
         }
     }
 


### PR DESCRIPTION
#### Type of change(s)
- [x] Bug fix

#### What changed and why
With autosave turned off, tapping **Save** on a text note hid the Save icon correctly, but swiping to another note and back made the icon reappear on a note that had no unsaved changes.

Root cause: Save-icon visibility is computed in `MainActivity.currentNoteTextChanged()` as `showSaveButton = newText != mCurrentNote.value`, which is re-run on every swipe-back via `TextFragment.setMenuVisibility(true)`. `saveCurrentNote()` refreshed `mCurrentNote.value` only for `TYPE_CHECKLIST` notes; for `TYPE_TEXT` notes it left the stale pre-save value in place. Because `mCurrentNote` is the same object reference as `mNotes[currentItem]`, the stale value survived the page change, so the recomputed comparison `savedText != stalePreSaveValue` evaluated to `true` and the Save icon came back.

Fix: add the symmetric `else` branch to `saveCurrentNote()` so the in-memory value of a text note is refreshed from the current EditText content right after a save (`mCurrentNote.value = getCurrentNoteText() ?: mCurrentNote.value`). This mirrors the existing checklist handling and keeps `mCurrentNote.value` in sync with what was persisted, so the swipe-back recomputation correctly yields `false`. The `?: mCurrentNote.value` fallback preserves the old value if the fragment view is unavailable.

#### Tests performed
Built the `fossDebug` variant and verified on an Android 15 (API 35) emulator:

Autosave OFF; created 2 text notes; typed in Note A (Save icon appeared), tapped Save (icon hid), swiped to Note B and back to Note A - Save icon stayed hidden (fix); typed a char - Save icon reappeared (dirty detection intact).

Also confirmed `detekt`, `lint`, unit tests and the build all pass locally (CI-equivalent).

#### Closes the following issue(s)
- Closes #210

#### Checklist
- [x] I read the contribution guidelines.
- [x] I manually tested my changes on device/emulator.
- [x] I updated the "Unreleased" section in `CHANGELOG.md` (if applicable).
- [x] I have self-reviewed my pull request (no typos, formatting errors, etc.).
- [x] I understand every change in this pull request.

---
<sub>Coded with Opus 4.8 ultracode.</sub>
